### PR TITLE
disable PipeChainStart

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -107,7 +107,7 @@
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},
-        {Credo.Check.Refactor.PipeChainStart},
+        {Credo.Check.Refactor.PipeChainStart, false},
         {Credo.Check.Refactor.UnlessWithElse},
 
         {Credo.Check.Warning.BoolOperationOnSameValues},


### PR DESCRIPTION
I suggest that we disable PipeChainStart as I don't think it makes sense
to always use a raw value for a pipeline. Ex:

Given this code:

```ex
defp any_event_since?(history, event, sentinel) do
  filter_events_since(history, event, sentinel)
  |> Enum.any?()
end
```

Credo suggests we refactor it to:

```ex
defp any_event_since?(history, event, sentinel) do
  history
  |> filter_events_since(event, sentinel)
  |> Enum.any?()
end
```

I'm not sure this really adds anything to the code though

Thoughts? @acj @mdenomy @grantovich 