### PR TITLE
disable AliasUsage

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -63,7 +63,7 @@
         # For some checks, like AliasUsage, you can only customize the priority
         # Priority values are: `low, normal, high, higher`
         #
-        {Credo.Check.Design.AliasUsage, priority: :low},
+        {Credo.Check.Design.AliasUsage, false},
 
         # For others you can set parameters
 


### PR DESCRIPTION
Credo will currently warn if aliases are not used for modules. Ex:

Given the code in `Autoscale.CooldownProxyScaler`:

```ex
def handle_call({:scale_down, metadata}, _, state) do
  case Autoscale.Scaler.scale_down(state.scaler, metadata) do
    :ok ->
      state = record_event_in_history(state, {{:fulfilled, :scale_down}, Timex.now()})
      {:reply, :ok, state}

    res ->
      {:reply, res, state}
  end
end
```

Credo will warn that `Autoscale.Scaler` is not aliased.

In my opinion aliasing is a gut decision for cleaning up the code. It
can be useful for reducing the number of characters but sometimes it
just seems more clear to be explicit about which module we're calling.

Thoughts?