### PR TITLE
disable PreferImplicitTry

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -89,7 +89,7 @@
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
         {Credo.Check.Readability.ParenthesesInCondition},
         {Credo.Check.Readability.PredicateFunctionNames},
-        {Credo.Check.Readability.PreferImplicitTry},
+        {Credo.Check.Readability.PreferImplicitTry, false},
         {Credo.Check.Readability.RedundantBlankLines},
         {Credo.Check.Readability.StringSigils},
         {Credo.Check.Readability.TrailingBlankLine},


### PR DESCRIPTION
Motivating PR discussion: https://github.com/wistia/modern-pastry/pull/876#discussion_r146277675

Polling whether we care to enforce implicit `try`/`rescue`. E.g.

```ex
def cool_func(funk) do
  bring_the(funk)
rescue
  :the_funk_is_dead
end
```

and not

```ex
def cool_func(funk) do
  try do
    bring_the(funk)
  rescue
    :the_funk_is_dead
  end
end
```